### PR TITLE
add restaurant name for each cart item in admin orders page

### DIFF
--- a/src/pages/Admin.js
+++ b/src/pages/Admin.js
@@ -144,6 +144,9 @@ const Admin = () => {
                                                     alt={cartItem?.menuItem?.card?.info?.name}
                                                 />
                                                 <div className="flex flex-col justify-between w-full pb-4">
+                                                     <p className="text-gray-600">
+                                                        {cartItem?.name}
+                                                    </p>
                                                     <h3 className="text-lg font-semibold">
                                                         {cartItem?.menuItem?.card?.info?.name}
                                                     </h3>


### PR DESCRIPTION
Title: Add restaurant name for each cart item in admin orders page

Description:
This pull request introduces a feature to display the restaurant name for each cart item in the admin orders page. Currently, the admin orders page only shows the item details without any reference to the restaurant it belongs to. This enhancement provides better visibility and context to the administrators while managing orders.

Changes Made:
Modified the Admin.js. Added new p tag to show restaurant name above order item name.

Testing:
Manually tested the feature by visiting admin orders page. (Local Env)

This change resolves #40
Please review this pull request and provide your feedback. Thank you!